### PR TITLE
Add force-seq? option to xml-seq->edn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.5.0 / 2021 Apr 19
+
+> This release ...
+
+* **Add** - add `force-seq?` option to `xml-str->edn`
+
 ## v1.4.0 / 2021 Apr 16
 
 > This release ...

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Each of these functions accepts an option map as an optional second argument, su
 * `remove-empty-attrs?` - to remove any empty attribute maps
 * `stringify-values?`   - to coerce non-nil, non-string, non-collection values to strings
 * `remove-newlines?`    - to remove any newline characters in `xml-str`. Only applicable for `xml-str->edn`
+* `force-seq?`          - to coerce child XML nodes into an array of maps. Only applicable for `xml-str->edn`
 
 `xml-str->edn` and `xml-source->edn` also support the parsing options from `clojure.data.xml` and Java's `XMLInputFactory` class.
 [Additional documentation](http://docs.oracle.com/javase/6/docs/api/javax/xml/stream/XMLInputFactory.html) from Oracle is available.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.wallbrew/clj-xml "1.4.0"
+(defproject com.wallbrew/clj-xml "1.5.0"
   :description "The missingg link between clj and xml"
   :url "https://github.com/nnichols/clj-xml"
   :license {:name "MIT"

--- a/src/clj_xml/core.clj
+++ b/src/clj_xml/core.clj
@@ -19,7 +19,8 @@
   ([xml-seq]
    (xml-seq->edn xml-seq {}))
 
-  ([xml-seq {:keys [stringify-values?]
+  ([xml-seq {:keys [stringify-values? 
+                    force-seq?]
              :as   opts}]
    (let [xml-transformer (fn [x] (xml->edn x opts))]
      (cond
@@ -29,7 +30,8 @@
             (or (nil? (first xml-seq))
                 (string? (first xml-seq)))) (first xml-seq)
        (and (impl/unique-tags? xml-seq)
-            (> (count xml-seq) 1))          (reduce into {} (mapv xml-transformer xml-seq))
+            (> (count xml-seq) 1)
+            (not force-seq?))      (reduce into {} (mapv xml-transformer xml-seq))
        (and (map? xml-seq)
             (empty? xml-seq))               {}
        (map? xml-seq)                       (xml-transformer xml-seq)
@@ -97,6 +99,7 @@
      stringify-values?   - to coerce non-nil, non-string, non-collection values to strings
      remove-empty-attrs? - to remove any empty attribute maps
      remove-newlines?    - to remove any newline characters in `xml-str`
+     force-seq?          - to coerce child XML nodes into a sequence of maps
 
    It also surfaces the original options from `clojure.data.xml/parse-str`
      include-node?                - a subset of #{:element :characters :comment} default #{:element :characters}

--- a/src/clj_xml/core.clj
+++ b/src/clj_xml/core.clj
@@ -12,10 +12,11 @@
    By default, this also mutates keys from XML_CASE to lisp-case and ignores XML attributes within tags.
 
    To change this behavior, an option map be provided with the following keys:
-     preserve-keys? - to maintain the exact keyword structure provided by `clojure.xml/parse`
-     preserve-attrs? - to maintain embedded XML attributes
-     stringify-values? - to coerce non-nil, non-string, non-collection values to strings
-     remove-empty-attrs? - to remove any empty attribute maps"
+     preserve-keys?      - to maintain the exact keyword structure provided by `clojure.xml/parse`
+     preserve-attrs?     - to maintain embedded XML attributes
+     stringify-values?   - to coerce non-nil, non-string, non-collection values to strings
+     remove-empty-attrs? - to remove any empty attribute maps
+     force-seq?          - to coerce child XML nodes into a sequence of maps"
   ([xml-seq]
    (xml-seq->edn xml-seq {}))
 
@@ -31,7 +32,7 @@
                 (string? (first xml-seq)))) (first xml-seq)
        (and (impl/unique-tags? xml-seq)
             (> (count xml-seq) 1)
-            (not force-seq?))      (reduce into {} (mapv xml-transformer xml-seq))
+            (not force-seq?))               (reduce into {} (mapv xml-transformer xml-seq))
        (and (map? xml-seq)
             (empty? xml-seq))               {}
        (map? xml-seq)                       (xml-transformer xml-seq)

--- a/test/clj_xml/core_test.clj
+++ b/test/clj_xml/core_test.clj
@@ -47,6 +47,14 @@
            :SEGMENTS [{:SEGMENT "more data"}
                       {:SEGMENT "more fake data"}]}}})
 
+(def edn-example-original-keys-force-seq
+  {:TEST_DOCUMENT
+   [{:HEAD [{:META_DATA "Some Fake Data!"}
+            {:META_DATA "Example Content"}]}
+    {:FILE [{:GROUPS [{:GROUP "test-data-club"}]}
+            {:SEGMENTS [{:SEGMENT "more data"}
+                        {:SEGMENT "more fake data"}]}]}]})
+
 (def edn-example-with-attrs
   {:test-document
    {:head [{:meta-data "Some Fake Data!" :meta-data-attrs {:type "title"}}
@@ -80,6 +88,7 @@
     (is (= (sut/xml->edn xml-example {:preserve-attrs? true}) edn-example-with-attrs))
     (is (= (sut/xml->edn xml-example {:preserve-attrs? true :remove-empty-attrs? true}) (update-in edn-example-with-attrs [:test-document :file] dissoc :groups-attrs)))
     (is (= (sut/xml->edn xml-example {:preserve-keys? true :preserve-attrs? true}) edn-example-with-attrs-and-original-keys))
+    (is (= (sut/xml->edn xml-example {:preserve-keys? true :force-seq? true}) edn-example-original-keys-force-seq))
     (is (nil? (sut/xml->edn nil)))
     (is (nil? (sut/xml->edn :edn)))
     (is (= (sut/xml->edn {}) {}))


### PR DESCRIPTION
Changes proposed in this merge request:

- Additions: `force-seq?` option added to xml-seq->edn
- Updates:
- Deletions:

### Pre-merge Checklist

- [x] Write + run tests
- [x] Update CHANGELOG and increment version
