### PR TITLE
Use cs/split-lines over regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.6.2 / 2021 May 27
+
+> This release fixes an issue parsing hand-formatted XML files that split attributes with newline characters
+
+* **Fix** ^^^
+
 ## v1.6.1 / 2021 May 06
 
 > This release fixes a typo in the project manifest

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.wallbrew/clj-xml "1.6.1"
+(defproject com.wallbrew/clj-xml "1.6.2"
   :description "The missing link between clj and xml"
   :url "https://github.com/nnichols/clj-xml"
   :license {:name "MIT"

--- a/src/clj_xml/impl.clj
+++ b/src/clj_xml/impl.clj
@@ -45,10 +45,10 @@
 (defn deformat
   "Remove line termination formatting specific to Windows (since we're ingesting XML) and double spacing"
   [s {:keys [remove-newlines?]}]
-  (cond-> s
-    :always          (cs/replace #"\r\n" "")
-    :always          (cs/replace #"\s\s+" "")
-    remove-newlines? (cs/replace #"\n" "")))
+  (let [trimmed-str (if remove-newlines?
+                      (apply str (cs/split-lines s))
+                      (cs/replace s #"\r\n" "\n"))]
+    (cs/replace trimmed-str #"  " " ")))
 
 (defn update-vals
   "Return `m` with `f` applied to each val in `m` with its `args`"


### PR DESCRIPTION
Changes proposed in this merge request:

- Updates: Use split lines to more directly handle vertical spacing in XML strings.

### Pre-merge Checklist

- [x] Write + run tests
- [ ] Update CHANGELOG and increment version
