### PR TITLE
Use `update-keys` and `update-vals` from Clojure 1.11.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ pom.xml.asc
 .lein-failures
 .nrepl-port
 .cpcache/
+.clj-kondo/.cache/
+.portal/
+.calva/
+.lsp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v1.6.2 / 2022 May 17
+
+> This release updates to use Clojure 1.11.1 and the new `update-vals` and `update-keys` functions.
+
+* **Add** - VS Code/Calva files to gitignore
+* **Update** - Update Clojure to 1.11.1. Use new functions in place of existing.
+
 ## v1.6.2 / 2021 May 27
 
 > This release fixes an issue parsing hand-formatted XML files that split attributes with newline characters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v1.6.2 / 2022 May 17
+## v1.7.0 / 2022 May 17
 
 > This release updates to use Clojure 1.11.1 and the new `update-vals` and `update-keys` functions.
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.wallbrew/clj-xml "1.6.2"
+(defproject com.wallbrew/clj-xml "1.7.0"
   :description "The missing link between clj and xml"
   :url "https://github.com/nnichols/clj-xml"
   :license {:name "MIT"

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/nnichols/clj-xml"
   :license {:name "MIT"
             :url  "https://opensource.org/licenses/MIT"}
-  :dependencies [[org.clojure/clojure "1.10.3"]
+  :dependencies [[org.clojure/clojure "1.11.1"]
                  [org.clojure/data.xml "0.2.0-alpha6"]]
   :profiles {:uberjar {:aot :all}}
   :min-lein-version "2.5.3")

--- a/src/clj_xml/core.clj
+++ b/src/clj_xml/core.clj
@@ -122,7 +122,7 @@
      (if (and attrs preserve-attrs?)
        (let [attrs-suffix (if preserve-keys? "_ATTRS" "-attrs")
              attrs-key    (keyword (str (name edn-tag) attrs-suffix))
-             attrs-val    (impl/update-vals (impl/update-keys attrs kw-function) val-function)
+             attrs-val    (update-vals (update-keys attrs kw-function) val-function)
              add-attrs?   (or (not remove-empty-attrs?)
                               (and remove-empty-attrs? (seq attrs-val)))]
          (merge {edn-tag edn-value}
@@ -299,8 +299,8 @@
                                           xml-content (edn->xml (get edn t) opts)
                                           xml-attrs   (when (contains? attrs-set (name t))
                                                         (-> (get edn (impl/tag->attrs-tag t from-xml-case?))
-                                                            (impl/update-keys kw-function)
-                                                            (impl/update-vals val-function)))]
+                                                            (update-keys kw-function)
+                                                            (update-vals val-function)))]
                                       {:tag     xml-tag
                                        :content xml-content
                                        :attrs   xml-attrs}))]

--- a/src/clj_xml/impl.clj
+++ b/src/clj_xml/impl.clj
@@ -57,15 +57,3 @@
                       (apply str (cs/split-lines s))
                       (cs/replace s #"\r\n" "\n"))]
     (cs/replace trimmed-str #"  " " ")))
-
-
-(defn update-vals
-  "Return `m` with `f` applied to each val in `m` with its `args`"
-  [m f & args]
-  (reduce-kv (fn [m' k v] (assoc m' k (apply f v args))) {} m))
-
-
-(defn update-keys
-  "Return `m` with `f` applied to each key in `m` with its `args`"
-  [m f & args]
-  (reduce-kv (fn [m' k v] (assoc m' (apply f k args) v)) {} m))

--- a/test/clj_xml/impl_test.clj
+++ b/test/clj_xml/impl_test.clj
@@ -32,17 +32,3 @@
     (t/is (= :HTML_ATTRS (sut/tag->attrs-tag "HTML" true)))
     (t/is (= :HTML_ATTRS (sut/tag->attrs-tag :HTML true)))
     (t/is (= :edn-attrs (sut/tag->attrs-tag "edn" false)))))
-
-
-(t/deftest update-vals-test
-  (t/testing "Functional correctness"
-    (t/is (= {:a 2 :b 3} (sut/update-vals {:a 1 :b 2} inc)))
-    (t/is (= {} (sut/update-vals {} dec)))
-    (t/is (= {:b 3 :c 4} (sut/update-vals {:b 1 :c 2} + 2)))))
-
-
-(t/deftest update-keys-test
-  (t/testing "Functional correctness"
-    (t/is (= {"a" 2 "b" 3} (sut/update-keys {:a 2 :b 3} name)))
-    (t/is (= {} (sut/update-keys {} dec)))
-    (t/is (= {":b-key" 3 ":c-key" 4} (sut/update-keys {:b 3 :c 4} str "-key")))))


### PR DESCRIPTION
# Proposed Changes

This fixes Issue #19.

- Updates: Update Clojure to 1.11.1. Use new core functions in place of existing `update-keys` and `update-vals`.
- Deletions: Unneeded tests

## Pre-merge Checklist

- [x] Write + run tests
- [x] Update CHANGELOG and increment version
- [x] Update README and relevant documentation
