### PR TITLE
[WB-17]: Update all CI CD jobs to use newest checkout action

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v2.3.4
+      uses: actions/checkout@v3.0.2
 
     - name: Cache maven dependencies
       uses: actions/cache@v2

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: Checkout Latest Commit
-      uses: actions/checkout@v2.3.4
+      uses: actions/checkout@v3.0.2
 
     - name: Check deps
       uses: nnichols/leiningen-dependency-update-action@v1

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -22,8 +22,10 @@ jobs:
       - name: Format Clojure code
         run: |
           cljstyle fix --report --report-timing $(find . -regextype posix-extended -regex '.*\.clj[csx]?$')
+          git status
 
-      - uses: stefanzweifel/git-auto-commit-action@v4.14.1
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v4.14.1
         with:
           commit_message: |
             [Format] Auto-formatting

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.0.2
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.WALL_BREW_BOT_PAT }}

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Format Clojure code
         run: |
-          cljstyle fix --report --report-timing $(find . -regextype posix-extended -regex '.*\.clj[csx]?$')
+          cljstyle fix --report --report-timing
           git status
 
       - name: Commit changes

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           cljstyle fix --report --report-timing $(find . -regextype posix-extended -regex '.*\.clj[csx]?$')
 
-      - uses: stefanzweifel/git-auto-commit-action@v4
+      - uses: stefanzweifel/git-auto-commit-action@v4.14.1
         with:
           commit_message: |
             [Format] Auto-formatting

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Format Clojure code
         run: |
-          cljstyle fix --report --report-timing
+          cljstyle fix --report --report-timing --verbose
           git status
 
       - name: Commit changes

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/labeler@v2
+    - uses: actions/checkout@v3.0.2
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3.0.2
         with:
           ref: ${{ github.head_ref }}
 
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3.0.2
         with:
           ref: ${{ github.head_ref }}
 

--- a/src/clj_xml/core.clj
+++ b/src/clj_xml/core.clj
@@ -6,7 +6,7 @@
 
 (def every-child
   "An alias for the ::every namespaced keyword"
-  ::every)
+                     ::every)
 
 
 (def first-child

--- a/src/clj_xml/core.clj
+++ b/src/clj_xml/core.clj
@@ -6,7 +6,7 @@
 
 (def every-child
   "An alias for the ::every namespaced keyword"
-                     ::every)
+  ::every)
 
 
 (def first-child


### PR DESCRIPTION
# Proposed Changes

- Additions:
- Updates: Use `actions/checkout@v3.0.2` to fix breaking git CLI change
- Deletions:
