### PR TITLE
[WB-18]: Dependency dispatch as WallBrewBot

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Check deps
       uses: nnichols/leiningen-dependency-update-action@v1
       with:
-        github-token: ${{ secrets.github_token }}
-        git-email: nichols1991@gmail.com
-        git-username: nnichols
+        github-token: ${{ secrets.WALL_BREW_BOT_PAT }}
+        git-email: the.wall.brew@gmail.com
+        git-username: WallBrewBot
         skips: "pom"

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -8,6 +8,6 @@ jobs:
     steps:
     - uses: actions/first-interaction@v1
       with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        repo-token: ${{ secrets.WALL_BREW_BOT_PAT }}
         issue-message: 'Thank you for taking the time to let us know!'
         pr-message: 'Congratulations! This is your first PR to clj-xml!'

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -9,4 +9,4 @@ jobs:
     steps:
     - uses: actions/checkout@v3.0.2
       with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        repo-token: "${{ secrets.WALL_BREW_BOT_PAT }}"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       - name: misspell
         uses: reviewdog/action-misspell@v1
         with:
-          github_token: ${{ secrets.github_token }}
+          github_token: ${{ secrets.WALL_BREW_BOT_PAT }}
           locale: "US"
           reporter: github-pr-review
           filter_mode: file

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,12 +28,9 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
-      - name: Install clj-kondo
-        uses: DeLaGuardo/setup-clj-kondo@master
-        with:
-          version: '2021.06.01'
-
       - name: Lint Clojure
-        run: |
-          clj-kondo --config ./dev/lint/clj-kondo.edn --lint \
-            $(find . -type f -regex ".*\.clj[csx]?$")
+        uses: nnichols/clojure-lint-action@v1
+        with:
+          github_token: ${{ secrets.WALL_BREW_BOT_PAT }}
+          reporter: github-pr-review
+          filter_mode: file

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/stale@v3.0.19
       with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        repo-token: ${{ secrets.WALL_BREW_BOT_PAT }}
         days-before-issue-stale: 30
         days-before-pr-stale: 10
         days-before-close: 10


### PR DESCRIPTION
# Proposed Changes

- Updates: Use @WallBrewBot as commit source for actions to ensure CI/CD runs against automated PRs
