### PR TITLE
Fix Pre-clojure 1.11 compatibility

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -3,6 +3,7 @@ name: Clojure Dependency Update
 on:
   schedule:
     - cron: '0 15 * * *'
+  workflow_dispatch:
 
 jobs:
   dependency-update:
@@ -14,7 +15,7 @@ jobs:
       uses: actions/checkout@v3.0.2
 
     - name: Check deps
-      uses: nnichols/leiningen-dependency-update-action@v1
+      uses: nnichols/clojure-dependency-update-action@v4
       with:
         github-token: ${{ secrets.WALL_BREW_BOT_PAT }}
         git-email: the.wall.brew@gmail.com

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Lint Clojure
-        uses: nnichols/clojure-lint-action@9685f2f64fe342c790a0a356d8378f678f634a96
+        uses: nnichols/clojure-lint-action@73f01e85207042e154633b7c849b439aba128b89
         with:
           github_token: ${{ secrets.WALL_BREW_BOT_PAT }}
           reporter: github-pr-review

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Lint Clojure
-        uses: nnichols/clojure-lint-action@98e94f7cfeaa84b19c93f2b960b7f9f3afa89758
+        uses: nnichols/clojure-lint-action@659c215b8080b57e7f71d61e5faae74bf5c706b4
         with:
           github_token: ${{ secrets.WALL_BREW_BOT_PAT }}
           reporter: github-pr-review

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Lint Clojure
-        uses: nnichols/clojure-lint-action@e5acf1c594bf3af6965c9922c3f509bad2c1ff7d
+        uses: nnichols/clojure-lint-action@969dd3f1b5b651ed3de6b8c43c76fd64485782ba
         with:
           github_token: ${{ secrets.WALL_BREW_BOT_PAT }}
           reporter: github-pr-review

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Lint Clojure
-        uses: nnichols/clojure-lint-action@f1729f6548d68a035c300c2d5f365189223e695b
+        uses: nnichols/clojure-lint-action@e5acf1c594bf3af6965c9922c3f509bad2c1ff7d
         with:
           github_token: ${{ secrets.WALL_BREW_BOT_PAT }}
           reporter: github-pr-review

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Lint Clojure
-        uses: nnichols/clojure-lint-action@6abd9fe4a845c9af56ada2bb7aad682aec12094d
+        uses: nnichols/clojure-lint-action@98e94f7cfeaa84b19c93f2b960b7f9f3afa89758
         with:
           github_token: ${{ secrets.WALL_BREW_BOT_PAT }}
           reporter: github-pr-review

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Lint Clojure
-        uses: nnichols/clojure-lint-action@v1
+        uses: nnichols/clojure-lint-action@9685f2f64fe342c790a0a356d8378f678f634a96
         with:
           github_token: ${{ secrets.WALL_BREW_BOT_PAT }}
           reporter: github-pr-review

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Lint Clojure
-        uses: nnichols/clojure-lint-action@ab9958ceea3fea4293a6169ff3faa9442d5b99c1
+        uses: nnichols/clojure-lint-action@v2
         with:
           github_token: ${{ secrets.WALL_BREW_BOT_PAT }}
           reporter: github-pr-review

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Lint Clojure
-        uses: nnichols/clojure-lint-action@v1
+        uses: nnichols/clojure-lint-action@6abd9fe4a845c9af56ada2bb7aad682aec12094d
         with:
           github_token: ${{ secrets.WALL_BREW_BOT_PAT }}
           reporter: github-pr-review

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Lint Clojure
-        uses: nnichols/clojure-lint-action@969dd3f1b5b651ed3de6b8c43c76fd64485782ba
+        uses: nnichols/clojure-lint-action@ab9958ceea3fea4293a6169ff3faa9442d5b99c1
         with:
           github_token: ${{ secrets.WALL_BREW_BOT_PAT }}
           reporter: github-pr-review

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Lint Clojure
-        uses: nnichols/clojure-lint-action@73f01e85207042e154633b7c849b439aba128b89
+        uses: nnichols/clojure-lint-action@f1729f6548d68a035c300c2d5f365189223e695b
         with:
           github_token: ${{ secrets.WALL_BREW_BOT_PAT }}
           reporter: github-pr-review

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Lint Clojure
-        uses: nnichols/clojure-lint-action@659c215b8080b57e7f71d61e5faae74bf5c706b4
+        uses: nnichols/clojure-lint-action@v1
         with:
           github_token: ${{ secrets.WALL_BREW_BOT_PAT }}
           reporter: github-pr-review

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ pom.xml.asc
 .lein-failures
 .nrepl-port
 .cpcache/
+.clj-kondo/.cache/
+.lsp/

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,3 @@ pom.xml.asc
 .lein-failures
 .nrepl-port
 .cpcache/
-.clj-kondo/.cache/
-.portal/
-.calva/
-.lsp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v1.7.0 / 2022 May 17
+
+> This release updates to use Clojure 1.11.1 and the new `update-vals` and `update-keys` functions.
+
+* **Add** - VS Code/Calva files to gitignore
+* **Update** - Update Clojure to 1.11.1. Use new functions in place of existing.
+
 ## v1.6.2 / 2021 May 27
 
 > This release fixes an issue parsing hand-formatted XML files that split attributes with newline characters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## v1.7.1 / 2022 Jul 09
 
-> This release fixes a compatability issue with clojure versions 1.20.* and lower
+> This release fixes a compatibility issue with clojure versions 1.20.* and lower
 
 * **Fix** - Revert 1.7.0, and re-alias `update-keys` as `update-keys*` and `update-vals` as `update-vals*`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,3 @@
-## v1.7.0 / 2022 May 17
-
-> This release updates to use Clojure 1.11.1 and the new `update-vals` and `update-keys` functions.
-
-* **Add** - VS Code/Calva files to gitignore
-* **Update** - Update Clojure to 1.11.1. Use new functions in place of existing.
-
 ## v1.6.2 / 2021 May 27
 
 > This release fixes an issue parsing hand-formatted XML files that split attributes with newline characters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
+## v1.7.1 / 2022 Jul 09
+
+> This release fixes a compatability issue with clojure versions 1.20.* and lower
+
+* **Fix** - Revert 1.7.0, and re-alias `update-keys` as `update-keys*` and `update-vals` as `update-vals*`
+
 ## v1.7.0 / 2022 May 17
 
 > This release updates to use Clojure 1.11.1 and the new `update-vals` and `update-keys` functions.
 
-* **Add** - VS Code/Calva files to gitignore
 * **Update** - Update Clojure to 1.11.1. Use new functions in place of existing.
 
 ## v1.6.2 / 2021 May 27

--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,9 @@
-(defproject com.wallbrew/clj-xml "1.7.0"
+(defproject com.wallbrew/clj-xml "1.6.2"
   :description "The missing link between clj and xml"
   :url "https://github.com/nnichols/clj-xml"
   :license {:name "MIT"
             :url  "https://opensource.org/licenses/MIT"}
-  :dependencies [[org.clojure/clojure "1.11.1"]
+  :dependencies [[org.clojure/clojure "1.10.3"]
                  [org.clojure/data.xml "0.2.0-alpha6"]]
   :profiles {:uberjar {:aot :all}}
   :min-lein-version "2.5.3")

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.wallbrew/clj-xml "1.7.0"
+(defproject com.wallbrew/clj-xml "1.7.1"
   :description "The missing link between clj and xml"
   :url "https://github.com/nnichols/clj-xml"
   :license {:name "MIT"

--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,9 @@
-(defproject com.wallbrew/clj-xml "1.6.2"
+(defproject com.wallbrew/clj-xml "1.7.0"
   :description "The missing link between clj and xml"
   :url "https://github.com/nnichols/clj-xml"
   :license {:name "MIT"
             :url  "https://opensource.org/licenses/MIT"}
-  :dependencies [[org.clojure/clojure "1.10.3"]
+  :dependencies [[org.clojure/clojure "1.11.1"]
                  [org.clojure/data.xml "0.2.0-alpha6"]]
   :profiles {:uberjar {:aot :all}}
   :min-lein-version "2.5.3")

--- a/src/clj_xml/core.clj
+++ b/src/clj_xml/core.clj
@@ -81,7 +81,7 @@
    (xml-seq->edn xml-seq {}))
 
   ([xml-seq {:keys [stringify-values?
-                    force-seq? fake-key]
+                    force-seq?]
              :as   opts}]
    (let [xml-transformer (fn [x] (xml->edn x opts))]
      (cond

--- a/src/clj_xml/core.clj
+++ b/src/clj_xml/core.clj
@@ -81,7 +81,7 @@
    (xml-seq->edn xml-seq {}))
 
   ([xml-seq {:keys [stringify-values?
-                    force-seq?]
+                    force-seq? fake-key]
              :as   opts}]
    (let [xml-transformer (fn [x] (xml->edn x opts))]
      (cond

--- a/src/clj_xml/core.clj
+++ b/src/clj_xml/core.clj
@@ -122,7 +122,7 @@
      (if (and attrs preserve-attrs?)
        (let [attrs-suffix (if preserve-keys? "_ATTRS" "-attrs")
              attrs-key    (keyword (str (name edn-tag) attrs-suffix))
-             attrs-val    (update-vals (update-keys attrs kw-function) val-function)
+             attrs-val    (impl/update-vals (impl/update-keys attrs kw-function) val-function)
              add-attrs?   (or (not remove-empty-attrs?)
                               (and remove-empty-attrs? (seq attrs-val)))]
          (merge {edn-tag edn-value}
@@ -299,8 +299,8 @@
                                           xml-content (edn->xml (get edn t) opts)
                                           xml-attrs   (when (contains? attrs-set (name t))
                                                         (-> (get edn (impl/tag->attrs-tag t from-xml-case?))
-                                                            (update-keys kw-function)
-                                                            (update-vals val-function)))]
+                                                            (impl/update-keys kw-function)
+                                                            (impl/update-vals val-function)))]
                                       {:tag     xml-tag
                                        :content xml-content
                                        :attrs   xml-attrs}))]

--- a/src/clj_xml/core.clj
+++ b/src/clj_xml/core.clj
@@ -33,6 +33,8 @@
     For each element in `key-path`, `force-xml-seq-at-path` will traverse `xml-edn` one level
        - If the current node is a map, clj-xml expects a keyword to update
        - If the current node is a sequence, clj-xml expects one of the supplied namespaced keywords and will update the related members of that sequence"
+  {:added "1.6"
+   :see-also ["every-child" "first-child" "last-child"]}
   [xml-edn [key & key-seq]]
   (if key
     (cond
@@ -58,6 +60,8 @@
     For each element in `key-path`, `force-xml-seq-at-paths` will traverse `xml-edn` one level
        - If the current node is a map, clj-xml expects a keyword to update
        - If the current node is a sequence, clj-xml expects one of the supplied namespaced keywords and will update the related members of that sequence"
+  {:added "1.6"
+   :see-also ["every-child" "first-child" "last-child"]}
   [xml-edn key-paths]
   (let [reducing-fn (fn [running-xml path] (force-xml-seq-at-path running-xml path))]
     (reduce reducing-fn xml-edn key-paths)))
@@ -77,6 +81,7 @@
      stringify-values?   - to coerce non-nil, non-string, non-collection values to strings
      remove-empty-attrs? - to remove any empty attribute maps
      force-seq?          - to coerce child XML nodes into a sequence of maps"
+  {:added "1.0"}
   ([xml-seq]
    (xml-seq->edn xml-seq {}))
 
@@ -110,6 +115,7 @@
      preserve-attrs? - to maintain embedded XML attributes
      stringify-values? - to coerce non-nil, non-string, non-collection values to strings
      remove-empty-attrs? - to remove any empty attribute maps"
+  {:added "1.0"}
   ([xml-map]
    (xml-map->edn xml-map {}))
 
@@ -139,6 +145,7 @@
      stringify-values?   - A boolean, that if set to true, coerces non-nil, non-string, non-collection values to strings
      remove-empty-attrs? - A boolean, that if set to true, removes any empty attribute maps
      force-seq?          - A boolean, that if set to true, coerces child XML nodes into a sequence of maps"
+  {:added "1.0"}
   ([xml-doc]
    (xml->edn xml-doc {}))
 
@@ -156,6 +163,7 @@
 
 (defn xml->edn'
   "Wrapper around xml->edn to apply sequence coercion"
+  {:added "1.0"}
   ([xml-doc]
    (xml->edn' xml-doc {}))
 
@@ -191,6 +199,7 @@
      resolver                     - An instance of a XMLInputFactory/RESOLVER to use in place of defaults
      support-dtd                  - A boolean, that if set to false, disables DTD support in parsers
      skip-whitespace              - A boolean, that if set to true, removes whitespace only elements"
+  {:added "1.0"}
   ([xml-str]
    (xml-str->edn xml-str {}))
 
@@ -240,6 +249,7 @@
      resolver                     - An instance of a XMLInputFactory/RESOLVER to use in place of defaults
      support-dtd                  - A boolean, that if set to false, disables DTD support in parsers
      skip-whitespace              - A boolean, that if set to true, removes whitespace only elements"
+  {:added "1.0"}
   ([xml-source]
    (xml-source->edn xml-source {}))
 
@@ -267,9 +277,10 @@
 (defn edn-seq->xml
   "Transform an EDN sequence to the pseudo XML expected by `clojure.data.xml`.
    To change the default behavior, an option map may be provided with the following keys:
-   to-xml-case? - To modify the keys representing XML tags to XML_CASE
-   from-xml-case? - If the source EDN has XML_CASE keys
-   stringify-values? - to coerce non-nil, non-string, non-collection values to strings"
+     to-xml-case? - To modify the keys representing XML tags to XML_CASE
+     from-xml-case? - If the source EDN has XML_CASE keys
+     stringify-values? - to coerce non-nil, non-string, non-collection values to strings"
+  {:added "1.0"}
   ([edn]
    (edn-seq->xml edn {}))
 
@@ -283,6 +294,7 @@
      to-xml-case? - To modify the keys representing XML tags to XML_CASE
      from-xml-case? - If the source EDN has XML_CASE keys
      stringify-values? - to coerce non-nil, non-string, non-collection values to strings"
+  {:added "1.0"}
   ([edn]
    (edn-map->xml edn {}))
 
@@ -315,6 +327,7 @@
      to-xml-case? - To modify the keys representing XML tags to XML_CASE
      from-xml-case? - If the source EDN has XML_CASE keys
      stringify-values? - to coerce non-nil, non-string, non-collection values to strings"
+  {:added "1.0"}
   ([edn]
    (edn->xml edn {}))
 
@@ -341,6 +354,7 @@
    It also surfaces the original options from `clojure.data.xml/emit-str`
      encoding - The character encoding to use
      doctype - The DOCTYPE declaration to use"
+  {:added "1.0"}
   ([edn]
    (edn->xml-str edn {}))
 
@@ -367,6 +381,7 @@
    It also surfaces the original options from `clojure.data.xml/emit`
      encoding - The character encoding to use
      doctype - The DOCTYPE declaration to use"
+  {:added "1.0"}
   ([edn java-writer]
    (edn->xml-stream edn java-writer {}))
 

--- a/src/clj_xml/core.clj
+++ b/src/clj_xml/core.clj
@@ -122,7 +122,7 @@
      (if (and attrs preserve-attrs?)
        (let [attrs-suffix (if preserve-keys? "_ATTRS" "-attrs")
              attrs-key    (keyword (str (name edn-tag) attrs-suffix))
-             attrs-val    (impl/update-vals (impl/update-keys attrs kw-function) val-function)
+             attrs-val    (impl/update-vals* (impl/update-keys* attrs kw-function) val-function)
              add-attrs?   (or (not remove-empty-attrs?)
                               (and remove-empty-attrs? (seq attrs-val)))]
          (merge {edn-tag edn-value}
@@ -299,8 +299,8 @@
                                           xml-content (edn->xml (get edn t) opts)
                                           xml-attrs   (when (contains? attrs-set (name t))
                                                         (-> (get edn (impl/tag->attrs-tag t from-xml-case?))
-                                                            (impl/update-keys kw-function)
-                                                            (impl/update-vals val-function)))]
+                                                            (impl/update-keys* kw-function)
+                                                            (impl/update-vals* val-function)))]
                                       {:tag     xml-tag
                                        :content xml-content
                                        :attrs   xml-attrs}))]

--- a/src/clj_xml/impl.clj
+++ b/src/clj_xml/impl.clj
@@ -57,3 +57,15 @@
                       (apply str (cs/split-lines s))
                       (cs/replace s #"\r\n" "\n"))]
     (cs/replace trimmed-str #"  " " ")))
+
+
+(defn update-vals
+  "Return `m` with `f` applied to each val in `m` with its `args`"
+  [m f & args]
+  (reduce-kv (fn [m' k v] (assoc m' k (apply f v args))) {} m))
+
+
+(defn update-keys
+  "Return `m` with `f` applied to each key in `m` with its `args`"
+  [m f & args]
+  (reduce-kv (fn [m' k v] (assoc m' (apply f k args) v)) {} m))

--- a/src/clj_xml/impl.clj
+++ b/src/clj_xml/impl.clj
@@ -5,6 +5,7 @@
 
 (defn xml-tag->keyword
   "Take an XML tag as extracted by `clojure.data.xml` and turn it into a kebab-cased, lower case keyword"
+  {:added "1.0"}
   [xml-tag]
   (let [xml-str (cs/lower-case (name xml-tag))]
     (keyword (cs/replace xml-str "_" "-"))))
@@ -12,6 +13,7 @@
 
 (defn keyword->xml-tag
   "Take a clojure keyord and turn it into the form expected by `clojure.data.xml` by making it UPPER CASE and snake_cased"
+  {:added "1.0"}
   [edn-keyword]
   (let [edn-str (cs/upper-case (name edn-keyword))]
     (keyword (cs/replace edn-str "-" "_"))))
@@ -23,6 +25,7 @@
 
 (defn attrs-tag->tag
   "Remove a suffix of `-attrs/_ATTRS` from `attrs-tag`"
+  {:added "1.0"}
   [attrs-tag]
   (let [tag-length (count attrs-tag)]
     (subs attrs-tag 0 (- tag-length attrs-length))))
@@ -30,6 +33,7 @@
 
 (defn tag->attrs-tag
   "Transform `tag` to look like an attributes map tag by appending it with `-attrs/_ATTRS` pedending on the value of `upper-case?`"
+  {:added "1.0"}
   [tag upper-case?]
   (let [suffix (if upper-case? "_ATTRS" "-attrs")]
     (keyword (str (name tag) suffix))))
@@ -37,6 +41,7 @@
 
 (defn edn-attrs-tag?
   "Returns true iff the list of `all-tags` to see if it contains the normalized `tag`"
+  {:added "1.0"}
   [tag all-tags]
   (boolean (and (cs/ends-with? (cs/lower-case tag) "attrs")
                 (contains? all-tags (attrs-tag->tag tag)))))
@@ -44,6 +49,7 @@
 
 (defn unique-tags?
   "Take an XML sequence as formatted by `clojure.xml/parse`, and determine if it exclusively contains unique tags"
+  {:added "1.0"}
   [xml-seq]
   (let [unique-tag-count (count (distinct (keep :tag xml-seq)))
         tag-count        (count (map :tag xml-seq))]
@@ -52,6 +58,7 @@
 
 (defn deformat
   "Remove line termination formatting specific to Windows (since we're ingesting XML) and double spacing"
+  {:added "1.0"}
   [s {:keys [remove-newlines?]}]
   (let [trimmed-str (if remove-newlines?
                       (apply str (cs/split-lines s))
@@ -61,11 +68,15 @@
 
 (defn update-vals*
   "Return `m` with `f` applied to each val in `m` with its `args`"
+  {:added "1.0"
+   :changed "1.7"}
   [m f & args]
   (reduce-kv (fn [m' k v] (assoc m' k (apply f v args))) {} m))
 
 
 (defn update-keys*
   "Return `m` with `f` applied to each key in `m` with its `args`"
+  {:added "1.0"
+   :changed "1.7"}
   [m f & args]
   (reduce-kv (fn [m' k v] (assoc m' (apply f k args) v)) {} m))

--- a/src/clj_xml/impl.clj
+++ b/src/clj_xml/impl.clj
@@ -59,13 +59,13 @@
     (cs/replace trimmed-str #"  " " ")))
 
 
-(defn update-vals
+(defn update-vals*
   "Return `m` with `f` applied to each val in `m` with its `args`"
   [m f & args]
   (reduce-kv (fn [m' k v] (assoc m' k (apply f v args))) {} m))
 
 
-(defn update-keys
+(defn update-keys*
   "Return `m` with `f` applied to each key in `m` with its `args`"
   [m f & args]
   (reduce-kv (fn [m' k v] (assoc m' (apply f k args) v)) {} m))

--- a/test/clj_xml/core_test.clj
+++ b/test/clj_xml/core_test.clj
@@ -133,7 +133,7 @@
 (deftest xml-string-tests
   (testing "functional correctness"
     (is (= (cs/replace xml-test-string #"\n   " " ") ;; The formatting of xml-test-string spans multiple lines with spaces for alignment, this is stripped internally
-             (sut/edn->xml-str (sut/xml-str->edn xml-test-string {:preserve-attrs? true :support-dtd false :remove-newlines? true}) {:to-xml-case? true})))))
+           (sut/edn->xml-str (sut/xml-str->edn xml-test-string {:preserve-attrs? true :support-dtd false :remove-newlines? true}) {:to-xml-case? true})))))
 
 
 (deftest insignificant-whitespace-test
@@ -154,34 +154,34 @@
   (testing "Parsed XML can coerce child nodes to collections"
     (let [nested-data {:a {:b [1 2 3] :c {:d "e"}}}]
       (is (= (sut/force-xml-seq-at-path nested-data [:a :b sut/last-child])
-               {:a {:b [1 2 [3]] :c {:d "e"}}}))
+             {:a {:b [1 2 [3]] :c {:d "e"}}}))
       (is (= (sut/force-xml-seq-at-path nested-data [:a :b sut/first-child])
-               {:a {:b [[1] 2 3] :c {:d "e"}}}))
+             {:a {:b [[1] 2 3] :c {:d "e"}}}))
       (is (= (sut/force-xml-seq-at-path nested-data [:a :b sut/every-child])
-               {:a {:b [[1] [2] [3]] :c {:d "e"}}}))
+             {:a {:b [[1] [2] [3]] :c {:d "e"}}}))
       (is (= (sut/force-xml-seq-at-path nested-data [:a :c :d])
-               {:a {:b [1 2 3] :c {:d ["e"]}}}))
+             {:a {:b [1 2 3] :c {:d ["e"]}}}))
       (is (= (sut/force-xml-seq-at-path nested-data [:a :c :f])
-               {:a {:b [1 2 3] :c {:d "e" :f [nil]}}}))
+             {:a {:b [1 2 3] :c {:d "e" :f [nil]}}}))
       (is (thrown-with-msg? IllegalArgumentException
-                              #"The key :clj-xml.core/first is incompatible with class clojure.lang.PersistentArrayMap"
-              (sut/force-xml-seq-at-path nested-data [sut/first-child])))
+                            #"The key :clj-xml.core/first is incompatible with class clojure.lang.PersistentArrayMap"
+            (sut/force-xml-seq-at-path nested-data [sut/first-child])))
       (is (thrown-with-msg? IllegalArgumentException
-                              #"The key :c is incompatible with class clojure.lang.PersistentVector"
-              (sut/force-xml-seq-at-path nested-data [:a :b :c]))))))
+                            #"The key :c is incompatible with class clojure.lang.PersistentVector"
+            (sut/force-xml-seq-at-path nested-data [:a :b :c]))))))
 
 
 (deftest force-xml-seq-at-paths-test
   (testing "Parsed XML can coerce child nodes to collections"
     (let [nested-data {:a {:b [1 2 3] :c {:d "e"}}}]
       (is (= (sut/force-xml-seq-at-paths nested-data [[:a :b sut/first-child] [:a :b sut/last-child] [:a]])
-               {:a [{:b [[1] 2 [3]] :c {:d "e"}}]}))
+             {:a [{:b [[1] 2 [3]] :c {:d "e"}}]}))
       (is (= (sut/force-xml-seq-at-paths nested-data [[:a] [:a sut/first-child :b]])
-               {:a [{:b [[1 2 3]] :c {:d "e"}}]})))))
+             {:a [{:b [[1 2 3]] :c {:d "e"}}]})))))
 
 
 (deftest xml-sequence-coercion-test
   (testing "parsed XML can be coerced"
     (is (= (sut/xml->edn' xml-example {:force-seq-for-paths [[:test-document :file :segments sut/every-child]
-                                                               [:test-document]]})
-             edn-example-with-targeted-coercion))))
+                                                             [:test-document]]})
+           edn-example-with-targeted-coercion))))

--- a/test/clj_xml/core_test.clj
+++ b/test/clj_xml/core_test.clj
@@ -1,7 +1,7 @@
 (ns clj-xml.core-test
   (:require [clj-xml.core :as sut]
             [clojure.string :as cs]
-            [clojure.test :as t]))
+            [clojure.test :refer :all]))
 
 
 (def xml-example
@@ -98,31 +98,31 @@
    :TEST_DOCUMENT_ATTRS {:XMLNS "https://www.fake.not/real"}})
 
 
-(t/deftest xml->edn-test
-  (t/testing "Functional correctness"
-    (t/is (= (sut/xml->edn xml-example) edn-example))
-    (t/is (= (sut/xml->edn xml-example {:preserve-keys? true}) edn-example-original-keys))
-    (t/is (= (sut/xml->edn xml-example {:preserve-attrs? true}) edn-example-with-attrs))
-    (t/is (= (sut/xml->edn xml-example {:preserve-attrs? true :remove-empty-attrs? true}) (update-in edn-example-with-attrs [:test-document :file] dissoc :groups-attrs)))
-    (t/is (= (sut/xml->edn xml-example {:preserve-keys? true :preserve-attrs? true}) edn-example-with-attrs-and-original-keys))
-    (t/is (= (sut/xml->edn xml-example {:preserve-keys? true :force-seq? true}) edn-example-original-keys-force-seq))
-    (t/is (nil? (sut/xml->edn nil)))
-    (t/is (nil? (sut/xml->edn :edn)))
-    (t/is (= (sut/xml->edn {}) {}))
-    (t/is (= (sut/xml->edn "XML") "XML"))))
+(deftest xml->edn-test
+  (testing "Functional correctness"
+    (is (= (sut/xml->edn xml-example) edn-example))
+    (is (= (sut/xml->edn xml-example {:preserve-keys? true}) edn-example-original-keys))
+    (is (= (sut/xml->edn xml-example {:preserve-attrs? true}) edn-example-with-attrs))
+    (is (= (sut/xml->edn xml-example {:preserve-attrs? true :remove-empty-attrs? true}) (update-in edn-example-with-attrs [:test-document :file] dissoc :groups-attrs)))
+    (is (= (sut/xml->edn xml-example {:preserve-keys? true :preserve-attrs? true}) edn-example-with-attrs-and-original-keys))
+    (is (= (sut/xml->edn xml-example {:preserve-keys? true :force-seq? true}) edn-example-original-keys-force-seq))
+    (is (nil? (sut/xml->edn nil)))
+    (is (nil? (sut/xml->edn :edn)))
+    (is (= (sut/xml->edn {}) {}))
+    (is (= (sut/xml->edn "XML") "XML"))))
 
 
-(t/deftest edn->xml-test
-  (t/testing "Functional correctness"
-    (t/is (= xml-example (sut/edn->xml (sut/xml->edn xml-example {:preserve-attrs? true}) {:to-xml-case? true :stringify-values? true})))
-    (t/is (= (sut/edn->xml edn-example-with-attrs-and-original-keys {:to-xml-case? true :from-xml-case? true :stringify-values? true}) xml-example))
-    (t/is (= (sut/edn->xml edn-example-with-attrs {:to-xml-case? true :stringify-values? true}) xml-example))
-    (t/is (= (sut/edn->xml nil) [nil]))
-    (t/is (nil? (sut/edn->xml :edn)))
-    (t/is (= (sut/edn->xml {}) {}))
-    (t/is (= (sut/edn->xml "XML") ["XML"]))
-    (t/is (= (sut/edn->xml 100 {:stringify-values? true}) "100"))
-    (t/is (nil? (sut/edn->xml 100)))))
+(deftest edn->xml-test
+  (testing "Functional correctness"
+    (is (= xml-example (sut/edn->xml (sut/xml->edn xml-example {:preserve-attrs? true}) {:to-xml-case? true :stringify-values? true})))
+    (is (= (sut/edn->xml edn-example-with-attrs-and-original-keys {:to-xml-case? true :from-xml-case? true :stringify-values? true}) xml-example))
+    (is (= (sut/edn->xml edn-example-with-attrs {:to-xml-case? true :stringify-values? true}) xml-example))
+    (is (= (sut/edn->xml nil) [nil]))
+    (is (nil? (sut/edn->xml :edn)))
+    (is (= (sut/edn->xml {}) {}))
+    (is (= (sut/edn->xml "XML") ["XML"]))
+    (is (= (sut/edn->xml 100 {:stringify-values? true}) "100"))
+    (is (nil? (sut/edn->xml 100)))))
 
 
 (def xml-test-string
@@ -130,58 +130,58 @@
    XSI=\"abc\"><HEAD><META_DATA TYPE=\"title\">Some Fake Data!</META_DATA> <META_DATA TYPE=\"tag\">Example Content</META_DATA></HEAD><FILE POSTER=\"JANE DOE &lt;j.doe@fake-email.not-real&gt;\" DATE=\"2020/04/12\" SUBJECT=\"TEST DATA\"><GROUPS><GROUP>test-data-club</GROUP></GROUPS><SEGMENTS><SEGMENT BITS=\"00111010\" NUMBER=\"58\">more data</SEGMENT><SEGMENT BYTES=\"10100010\" NUMBER=\"-94\">more fake data</SEGMENT></SEGMENTS></FILE></TEST_DOCUMENT>")
 
 
-(t/deftest xml-string-tests
-  (t/testing "functional correctness"
-    (t/is (= (cs/replace xml-test-string #"\n   " " ") ;; The formatting of xml-test-string spans multiple lines with spaces for alignment, this is stripped internally
+(deftest xml-string-tests
+  (testing "functional correctness"
+    (is (= (cs/replace xml-test-string #"\n   " " ") ;; The formatting of xml-test-string spans multiple lines with spaces for alignment, this is stripped internally
              (sut/edn->xml-str (sut/xml-str->edn xml-test-string {:preserve-attrs? true :support-dtd false :remove-newlines? true}) {:to-xml-case? true})))))
 
 
-(t/deftest insignificant-whitespace-test
-  (t/testing "Corner-cases around embedded insignificant whitespace"
+(deftest insignificant-whitespace-test
+  (testing "Corner-cases around embedded insignificant whitespace"
     (let [no-ws (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
                      "<someTag><foo>some text</foo> \n"
                      "</someTag>")
           ws (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
                   "<someTag> <foo>some text</foo> \n"
                   "</someTag>")]
-      (t/is (= {:sometag [{:foo "some text"}]} (sut/xml-str->edn no-ws {:skip-whitespace true})))
-      (t/is (= {:sometag [" " {:foo "some text"} " "]} (sut/xml-str->edn ws {:remove-newlines? true})))
-      (t/is (= {:sometag [{:foo "some text"}]} (sut/xml-str->edn ws {:skip-whitespace true})))
-      (t/is (= {:sometag {:foo "some text", :bar "bla"}} (sut/xml-str->edn (str "<sometag><foo>some text</foo><bar>bla</bar></sometag>") {:skip-whitespace true}))))))
+      (is (= {:sometag [{:foo "some text"}]} (sut/xml-str->edn no-ws {:skip-whitespace true})))
+      (is (= {:sometag [" " {:foo "some text"} " "]} (sut/xml-str->edn ws {:remove-newlines? true})))
+      (is (= {:sometag [{:foo "some text"}]} (sut/xml-str->edn ws {:skip-whitespace true})))
+      (is (= {:sometag {:foo "some text", :bar "bla"}} (sut/xml-str->edn (str "<sometag><foo>some text</foo><bar>bla</bar></sometag>") {:skip-whitespace true}))))))
 
 
-(t/deftest force-xml-seq-at-path-test
-  (t/testing "Parsed XML can coerce child nodes to collections"
+(deftest force-xml-seq-at-path-test
+  (testing "Parsed XML can coerce child nodes to collections"
     (let [nested-data {:a {:b [1 2 3] :c {:d "e"}}}]
-      (t/is (= (sut/force-xml-seq-at-path nested-data [:a :b sut/last-child])
+      (is (= (sut/force-xml-seq-at-path nested-data [:a :b sut/last-child])
                {:a {:b [1 2 [3]] :c {:d "e"}}}))
-      (t/is (= (sut/force-xml-seq-at-path nested-data [:a :b sut/first-child])
+      (is (= (sut/force-xml-seq-at-path nested-data [:a :b sut/first-child])
                {:a {:b [[1] 2 3] :c {:d "e"}}}))
-      (t/is (= (sut/force-xml-seq-at-path nested-data [:a :b sut/every-child])
+      (is (= (sut/force-xml-seq-at-path nested-data [:a :b sut/every-child])
                {:a {:b [[1] [2] [3]] :c {:d "e"}}}))
-      (t/is (= (sut/force-xml-seq-at-path nested-data [:a :c :d])
+      (is (= (sut/force-xml-seq-at-path nested-data [:a :c :d])
                {:a {:b [1 2 3] :c {:d ["e"]}}}))
-      (t/is (= (sut/force-xml-seq-at-path nested-data [:a :c :f])
+      (is (= (sut/force-xml-seq-at-path nested-data [:a :c :f])
                {:a {:b [1 2 3] :c {:d "e" :f [nil]}}}))
-      (t/is (thrown-with-msg? IllegalArgumentException
+      (is (thrown-with-msg? IllegalArgumentException
                               #"The key :clj-xml.core/first is incompatible with class clojure.lang.PersistentArrayMap"
               (sut/force-xml-seq-at-path nested-data [sut/first-child])))
-      (t/is (thrown-with-msg? IllegalArgumentException
+      (is (thrown-with-msg? IllegalArgumentException
                               #"The key :c is incompatible with class clojure.lang.PersistentVector"
               (sut/force-xml-seq-at-path nested-data [:a :b :c]))))))
 
 
-(t/deftest force-xml-seq-at-paths-test
-  (t/testing "Parsed XML can coerce child nodes to collections"
+(deftest force-xml-seq-at-paths-test
+  (testing "Parsed XML can coerce child nodes to collections"
     (let [nested-data {:a {:b [1 2 3] :c {:d "e"}}}]
-      (t/is (= (sut/force-xml-seq-at-paths nested-data [[:a :b sut/first-child] [:a :b sut/last-child] [:a]])
+      (is (= (sut/force-xml-seq-at-paths nested-data [[:a :b sut/first-child] [:a :b sut/last-child] [:a]])
                {:a [{:b [[1] 2 [3]] :c {:d "e"}}]}))
-      (t/is (= (sut/force-xml-seq-at-paths nested-data [[:a] [:a sut/first-child :b]])
+      (is (= (sut/force-xml-seq-at-paths nested-data [[:a] [:a sut/first-child :b]])
                {:a [{:b [[1 2 3]] :c {:d "e"}}]})))))
 
 
-(t/deftest xml-sequence-coercion-test
-  (t/testing "parsed XML can be coerced"
-    (t/is (= (sut/xml->edn' xml-example {:force-seq-for-paths [[:test-document :file :segments sut/every-child]
+(deftest xml-sequence-coercion-test
+  (testing "parsed XML can be coerced"
+    (is (= (sut/xml->edn' xml-example {:force-seq-for-paths [[:test-document :file :segments sut/every-child]
                                                                [:test-document]]})
              edn-example-with-targeted-coercion))))

--- a/test/clj_xml/impl_test.clj
+++ b/test/clj_xml/impl_test.clj
@@ -36,13 +36,13 @@
 
 (t/deftest update-vals-test
   (t/testing "Functional correctness"
-    (t/is (= {:a 2 :b 3} (sut/update-vals {:a 1 :b 2} inc)))
-    (t/is (= {} (sut/update-vals {} dec)))
-    (t/is (= {:b 3 :c 4} (sut/update-vals {:b 1 :c 2} + 2)))))
+    (t/is (= {:a 2 :b 3} (sut/update-vals* {:a 1 :b 2} inc)))
+    (t/is (= {} (sut/update-vals* {} dec)))
+    (t/is (= {:b 3 :c 4} (sut/update-vals* {:b 1 :c 2} + 2)))))
 
 
 (t/deftest update-keys-test
   (t/testing "Functional correctness"
-    (t/is (= {"a" 2 "b" 3} (sut/update-keys {:a 2 :b 3} name)))
-    (t/is (= {} (sut/update-keys {} dec)))
-    (t/is (= {":b-key" 3 ":c-key" 4} (sut/update-keys {:b 3 :c 4} str "-key")))))
+    (t/is (= {"a" 2 "b" 3} (sut/update-keys* {:a 2 :b 3} name)))
+    (t/is (= {} (sut/update-keys* {} dec)))
+    (t/is (= {":b-key" 3 ":c-key" 4} (sut/update-keys* {:b 3 :c 4} str "-key")))))

--- a/test/clj_xml/impl_test.clj
+++ b/test/clj_xml/impl_test.clj
@@ -32,3 +32,17 @@
     (t/is (= :HTML_ATTRS (sut/tag->attrs-tag "HTML" true)))
     (t/is (= :HTML_ATTRS (sut/tag->attrs-tag :HTML true)))
     (t/is (= :edn-attrs (sut/tag->attrs-tag "edn" false)))))
+
+
+(t/deftest update-vals-test
+  (t/testing "Functional correctness"
+    (t/is (= {:a 2 :b 3} (sut/update-vals {:a 1 :b 2} inc)))
+    (t/is (= {} (sut/update-vals {} dec)))
+    (t/is (= {:b 3 :c 4} (sut/update-vals {:b 1 :c 2} + 2)))))
+
+
+(t/deftest update-keys-test
+  (t/testing "Functional correctness"
+    (t/is (= {"a" 2 "b" 3} (sut/update-keys {:a 2 :b 3} name)))
+    (t/is (= {} (sut/update-keys {} dec)))
+    (t/is (= {":b-key" 3 ":c-key" 4} (sut/update-keys {:b 3 :c 4} str "-key")))))

--- a/test/clj_xml/impl_test.clj
+++ b/test/clj_xml/impl_test.clj
@@ -1,48 +1,48 @@
 (ns clj-xml.impl-test
   (:require [clj-xml.impl :as sut]
-            [clojure.test :as t]))
+            [clojure.test :refer :all]))
 
 
-(t/deftest tag-keyword-conversion-test
-  (t/testing "Tag formatted and EDN formatted keywords can be transformed"
-    (t/is (= :XML_TAG (sut/keyword->xml-tag :xml-tag)))
-    (t/is (= :edn-keyword (sut/xml-tag->keyword :EDN_KEYWORD)))
-    (t/is (= :XML_TAG (sut/keyword->xml-tag (sut/xml-tag->keyword :XML_TAG))))
-    (t/is (= :edn-keyword (sut/xml-tag->keyword (sut/keyword->xml-tag :edn-keyword))))))
+(deftest tag-keyword-conversion-test
+  (testing "Tag formatted and EDN formatted keywords can be transformed"
+    (is (= :XML_TAG (sut/keyword->xml-tag :xml-tag)))
+    (is (= :edn-keyword (sut/xml-tag->keyword :EDN_KEYWORD)))
+    (is (= :XML_TAG (sut/keyword->xml-tag (sut/xml-tag->keyword :XML_TAG))))
+    (is (= :edn-keyword (sut/xml-tag->keyword (sut/keyword->xml-tag :edn-keyword))))))
 
 
-(t/deftest unique-tags?-test
-  (t/testing "Functional correctness"
-    (t/is (true? (sut/unique-tags? [{:tag "One"} {:tag "Two"} {:tag "Three"}])))
-    (t/is (true? (sut/unique-tags? [])))
-    (t/is (true? (sut/unique-tags? [{:tag "One"}])))
-    (t/is (false? (sut/unique-tags? [{:tag "One"} {:tag "One"}])))))
+(deftest unique-tags?-test
+  (testing "Functional correctness"
+    (is (true? (sut/unique-tags? [{:tag "One"} {:tag "Two"} {:tag "Three"}])))
+    (is (true? (sut/unique-tags? [])))
+    (is (true? (sut/unique-tags? [{:tag "One"}])))
+    (is (false? (sut/unique-tags? [{:tag "One"} {:tag "One"}])))))
 
 
-(t/deftest attrs-tag->tag-test
-  (t/testing "Functional correctness"
-    (t/is (= "HTML" (sut/attrs-tag->tag "HTML_ATTRS")))
-    (t/is (= "edn" (sut/attrs-tag->tag "edn-attrs")))))
+(deftest attrs-tag->tag-test
+  (testing "Functional correctness"
+    (is (= "HTML" (sut/attrs-tag->tag "HTML_ATTRS")))
+    (is (= "edn" (sut/attrs-tag->tag "edn-attrs")))))
 
 
-(t/deftest tag->attrs-tag-test
-  (t/testing "Functional correctness"
-    (t/is (= :HTML-attrs (sut/tag->attrs-tag "HTML" false)))
-    (t/is (= :HTML-attrs (sut/tag->attrs-tag :HTML false)))
-    (t/is (= :HTML_ATTRS (sut/tag->attrs-tag "HTML" true)))
-    (t/is (= :HTML_ATTRS (sut/tag->attrs-tag :HTML true)))
-    (t/is (= :edn-attrs (sut/tag->attrs-tag "edn" false)))))
+(deftest tag->attrs-tag-test
+  (testing "Functional correctness"
+    (is (= :HTML-attrs (sut/tag->attrs-tag "HTML" false)))
+    (is (= :HTML-attrs (sut/tag->attrs-tag :HTML false)))
+    (is (= :HTML_ATTRS (sut/tag->attrs-tag "HTML" true)))
+    (is (= :HTML_ATTRS (sut/tag->attrs-tag :HTML true)))
+    (is (= :edn-attrs (sut/tag->attrs-tag "edn" false)))))
 
 
-(t/deftest update-vals-test
-  (t/testing "Functional correctness"
-    (t/is (= {:a 2 :b 3} (sut/update-vals* {:a 1 :b 2} inc)))
-    (t/is (= {} (sut/update-vals* {} dec)))
-    (t/is (= {:b 3 :c 4} (sut/update-vals* {:b 1 :c 2} + 2)))))
+(deftest update-vals-test
+  (testing "Functional correctness"
+    (is (= {:a 2 :b 3} (sut/update-vals* {:a 1 :b 2} inc)))
+    (is (= {} (sut/update-vals* {} dec)))
+    (is (= {:b 3 :c 4} (sut/update-vals* {:b 1 :c 2} + 2)))))
 
 
-(t/deftest update-keys-test
-  (t/testing "Functional correctness"
-    (t/is (= {"a" 2 "b" 3} (sut/update-keys* {:a 2 :b 3} name)))
-    (t/is (= {} (sut/update-keys* {} dec)))
-    (t/is (= {":b-key" 3 ":c-key" 4} (sut/update-keys* {:b 3 :c 4} str "-key")))))
+(deftest update-keys-test
+  (testing "Functional correctness"
+    (is (= {"a" 2 "b" 3} (sut/update-keys* {:a 2 :b 3} name)))
+    (is (= {} (sut/update-keys* {} dec)))
+    (is (= {":b-key" 3 ":c-key" 4} (sut/update-keys* {:b 3 :c 4} str "-key")))))


### PR DESCRIPTION
# Proposed Changes

- Additions: Re-introduce `update-keys` as `update-keys*` and `update-vals` as `update-vals*`

## Pre-merge Checklist

- [x] Write + run tests
- [x] Update CHANGELOG and increment version
- [x] Update README and relevant documentation
