### PR TITLE
Reduce eagerness

### DIFF
--- a/.wallbrew/sealog/changes/1-12-0.edn
+++ b/.wallbrew/sealog/changes/1-12-0.edn
@@ -1,0 +1,11 @@
+{:version      {:major 1
+                :minor 12
+                :patch 0}
+ :version-type :semver3
+ :changes      {:added      ["A new option `:limit-eagerness?` is available for all public functions. Enabling this option disables automatic, intermediate vector coercion."]
+                :changed    []
+                :deprecated []
+                :removed    []
+                :fixed      []
+                :security   []}
+ :timestamp    "2024-12-30T22:06:11.767347Z"}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Table of Contents
 
+* [1.12.0 - 2024-12-30](#1120---2024-12-30)
 * [1.11.0 - 2024-12-30](#1110---2024-12-30)
 * [1.10.0 - 2024-09-20](#1100---2024-09-20)
 * [1.9.1 - 2024-07-12](#191---2024-07-12)
@@ -24,6 +25,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * [1.2.0 - 2021-03-13](#120---2021-03-13)
 * [1.1.0 - 2020-12-14](#110---2020-12-14)
 * [1.0.0 - 2020-12-12](#100---2020-12-12)
+
+## 1.12.0 - 2024-12-30
+
+* Added
+  * A new option `:limit-eagerness?` is available for all public functions. Enabling this option disables automatic, intermediate vector coercion.
 
 ## 1.11.0 - 2024-12-30
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Each of these functions accepts an option map as an optional second argument, su
 
 | Option                 | Default Value |Description                                                                                                                          |
 |------------------------|---------------|-------------------------------------------------------------------------------------------------------------------------------------|
+| `:limit-eagerness?`    | `false`       | A boolean, that if set to true, disables automatic coercion to vectors for returned sequences                                       |
 | `:preserve-keys?`      | `false`       |Maintain the exact keyword structure provided by `clojure.xml/parse`                                                                 |
 | `:preserve-attrs?`     | `false`       |Maintain embedded XML attributes                                                                                                     |
 | `:remove-empty-attrs?` | `false`       |Remove any empty attribute maps                                                                                                      |
@@ -188,11 +189,12 @@ To convert EDN into XML, you'll want to use one of the following functions based
 
 Each of these functions accepts an option map as an optional final argument, supporting the following keys:
 
-| Option               | Default Value | Description                                                                           |
-|----------------------|---------------|---------------------------------------------------------------------------------------|
-| `:to-xml-case?`      | `false`       | Wether or not the keys representing XML tags will be coerced to XML_CASE              |
-| `:from-xml-case?`    | `false`       | Wether or not the source EDN is in XML_CASE                                           |
-| `:stringify-values?` | `false`       | Wether or not non-nil, non-string, non-collection values should be coerced to strings |
+| Option               | Default Value | Description                                                                                     |
+|----------------------|---------------|-------------------------------------------------------------------------------------------------|
+| `:limit-eagerness?`    | `false`       | A boolean, that if set to true, disables automatic coercion to vectors for returned sequences |
+| `:to-xml-case?`      | `false`       | Wether or not the keys representing XML tags will be coerced to XML_CASE                        |
+| `:from-xml-case?`    | `false`       | Wether or not the source EDN is in XML_CASE                                                     |
+| `:stringify-values?` | `false`       | Wether or not non-nil, non-string, non-collection values should be coerced to strings           |
 
 `edn->xml-str` and `edn->xml-stream` also support the parsing options from `clojure.data.xml`:
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.wallbrew</groupId>
   <artifactId>clj-xml</artifactId>
   <packaging>jar</packaging>
-  <version>1.11.0</version>
+  <version>1.12.0</version>
   <name>clj-xml</name>
   <description>The missing link between clj and xml</description>
   <url>https://github.com/Wall-Brew-Co/clj-xml</url>
@@ -20,7 +20,7 @@
     <url>https://github.com/Wall-Brew-Co/clj-xml</url>
     <connection>scm:git:git://github.com/Wall-Brew-Co/clj-xml.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/Wall-Brew-Co/clj-xml.git</developerConnection>
-    <tag>73eadc1a3113c58bf6521de0515b0c0f23d5048e</tag>
+    <tag>e57bb23e84714e15cdbf7d3d65927660361bd1f9</tag>
   </scm>
   <build>
     <sourceDirectory>src</sourceDirectory>

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.wallbrew/clj-xml "1.11.0"
+(defproject com.wallbrew/clj-xml "1.12.0"
   :description "The missing link between clj and xml"
   :url "https://github.com/Wall-Brew-Co/clj-xml"
   :license {:name         "MIT"

--- a/src/clj_xml/core.clj
+++ b/src/clj_xml/core.clj
@@ -59,19 +59,19 @@
   ([xml-edn key-path]
    (force-xml-seq-at-path xml-edn key-path {}))
   ([xml-edn [xml-key & key-seq] {:keys [limit-eagerness?]}]
-  (if xml-key
-    (cond
-      (and (sequential? xml-edn)
-           (= every-child xml-key))   (impl/map* #(force-xml-seq-at-path % key-seq) xml-edn limit-eagerness?)
-      (and (sequential? xml-edn)
-           (= first-child xml-key))   (cons (force-xml-seq-at-path (first xml-edn) key-seq) (rest xml-edn))
-      (and (sequential? xml-edn)
-           (= last-child xml-key))    (conj (into [] (butlast xml-edn)) (force-xml-seq-at-path (last xml-edn) key-seq))
-      (and (map? xml-edn)
-           (not (child-key? xml-key))
-           (keyword? xml-key))        (update xml-edn xml-key force-xml-seq-at-path key-seq)
-      :else                           (throw (IllegalArgumentException. (str "The key " xml-key " is incompatible with " (type xml-edn)))))
-    [xml-edn])))
+   (if xml-key
+     (cond
+       (and (sequential? xml-edn)
+            (= every-child xml-key))   (impl/map* #(force-xml-seq-at-path % key-seq) xml-edn limit-eagerness?)
+       (and (sequential? xml-edn)
+            (= first-child xml-key))   (cons (force-xml-seq-at-path (first xml-edn) key-seq) (rest xml-edn))
+       (and (sequential? xml-edn)
+            (= last-child xml-key))    (conj (into [] (butlast xml-edn)) (force-xml-seq-at-path (last xml-edn) key-seq))
+       (and (map? xml-edn)
+            (not (child-key? xml-key))
+            (keyword? xml-key))        (update xml-edn xml-key force-xml-seq-at-path key-seq)
+       :else                           (throw (IllegalArgumentException. (str "The key " xml-key " is incompatible with " (type xml-edn)))))
+     [xml-edn])))
 
 
 (defn force-xml-seq-at-paths
@@ -90,7 +90,7 @@
   ([xml-edn key-paths]
    (force-xml-seq-at-paths xml-edn key-paths {}))
   ([xml-edn key-paths opts]
-  (reduce #(force-xml-seq-at-path %1 %2 opts) xml-edn key-paths)))
+   (reduce #(force-xml-seq-at-path %1 %2 opts) xml-edn key-paths)))
 
 
 ;; Parsing XML into EDN

--- a/src/clj_xml/impl.clj
+++ b/src/clj_xml/impl.clj
@@ -169,3 +169,12 @@
    :no-doc  true}
   [m f & args]
   (reduce-kv (fn [m' k v] (assoc m' (apply f k args) v)) {} m))
+
+(defn map*
+  "Applies either `map` or `mapv`, depending on `limit-eagerness?`"
+  {:added  "1.12"
+   :no-doc true}
+  [f coll limit-eagerness?]
+  (if limit-eagerness?
+    (map f coll)
+    (mapv f coll)))

--- a/src/clj_xml/impl.clj
+++ b/src/clj_xml/impl.clj
@@ -170,6 +170,7 @@
   [m f & args]
   (reduce-kv (fn [m' k v] (assoc m' (apply f k args) v)) {} m))
 
+
 (defn map*
   "Applies either `map` or `mapv`, depending on `limit-eagerness?`"
   {:added  "1.12"

--- a/test/clj_xml/core_test.clj
+++ b/test/clj_xml/core_test.clj
@@ -167,9 +167,9 @@
                                            :limit-eagerness? true
                                            :force-seq?       true})))
     (is (nil?
-         (sut/xml->edn nil {:limit-eagerness? true})))
+          (sut/xml->edn nil {:limit-eagerness? true})))
     (is (nil?
-         (sut/xml->edn :edn {:limit-eagerness? true})))
+          (sut/xml->edn :edn {:limit-eagerness? true})))
     (is (match? {} (sut/xml->edn {} {:limit-eagerness? true})))
     (is (match? []
                 (sut/xml->edn [] {:limit-eagerness? true})))
@@ -314,10 +314,10 @@
                   {:a {:b [1 2 3] :c {:d "e" :f [nil]}}}))
       (is (thrown-with-msg? IllegalArgumentException
                             #"The key :clj-xml.core/first is incompatible with class clojure.lang.PersistentArrayMap"
-                            (sut/force-xml-seq-at-path nested-data [sut/first-child])))
+            (sut/force-xml-seq-at-path nested-data [sut/first-child])))
       (is (thrown-with-msg? IllegalArgumentException
                             #"The key :c is incompatible with class clojure.lang.PersistentVector"
-                            (sut/force-xml-seq-at-path nested-data [:a :b :c])))
+            (sut/force-xml-seq-at-path nested-data [:a :b :c])))
       (testing "Limiting eagerness does not impact correctness"
         (is (match? (sut/force-xml-seq-at-path nested-data [:a :b sut/last-child] {:limit-eagerness? true})
                     {:a {:b [1 2 [3]] :c {:d "e"}}}))
@@ -331,10 +331,10 @@
                     {:a {:b [1 2 3] :c {:d "e" :f [nil]}}}))
         (is (thrown-with-msg? IllegalArgumentException
                               #"The key :clj-xml.core/first is incompatible with class clojure.lang.PersistentArrayMap"
-                              (sut/force-xml-seq-at-path nested-data [sut/first-child] {:limit-eagerness? true})))
+              (sut/force-xml-seq-at-path nested-data [sut/first-child] {:limit-eagerness? true})))
         (is (thrown-with-msg? IllegalArgumentException
                               #"The key :c is incompatible with class clojure.lang.PersistentVector"
-                              (sut/force-xml-seq-at-path nested-data [:a :b :c] {:limit-eagerness? true})))))))
+              (sut/force-xml-seq-at-path nested-data [:a :b :c] {:limit-eagerness? true})))))))
 
 
 (deftest force-xml-seq-at-paths-test

--- a/test/clj_xml/core_test.clj
+++ b/test/clj_xml/core_test.clj
@@ -131,17 +131,49 @@
     (is (match? edn-example-with-attrs
                 (sut/xml->edn xml-example {:preserve-attrs? true})))
     (is (match? (update-in edn-example-with-attrs [:test-document :file] dissoc :groups-attrs)
-                (sut/xml->edn xml-example {:preserve-attrs? true :remove-empty-attrs? true})))
+                (sut/xml->edn xml-example {:preserve-attrs?     true
+                                           :remove-empty-attrs? true})))
     (is (match? edn-example-with-attrs-and-original-keys
-                (sut/xml->edn xml-example {:preserve-keys? true :preserve-attrs? true})))
+                (sut/xml->edn xml-example {:preserve-keys?  true
+                                           :preserve-attrs? true})))
     (is (match? edn-example-original-keys-force-seq
-                (sut/xml->edn xml-example {:preserve-keys? true :force-seq? true})))
+                (sut/xml->edn xml-example {:preserve-keys? true
+                                           :force-seq?     true})))
     (is (nil? (sut/xml->edn nil)))
     (is (nil? (sut/xml->edn :edn)))
     (is (match? {} (sut/xml->edn {})))
     (is (match? []
                 (sut/xml->edn [])))
-    (is (match? "XML" (sut/xml->edn "XML")))))
+    (is (match? "XML" (sut/xml->edn "XML"))))
+  (testing "Limiting eagerness does not impact correctness"
+    (is (match? edn-example
+                (sut/xml->edn xml-example {:limit-eagerness? true})))
+    (is (match? edn-example-original-keys
+                (sut/xml->edn xml-example {:preserve-keys?   true
+                                           :limit-eagerness? true})))
+    (is (match? edn-example-with-attrs
+                (sut/xml->edn xml-example {:preserve-attrs?  true
+                                           :limit-eagerness? true})))
+    (is (match? (update-in edn-example-with-attrs [:test-document :file] dissoc :groups-attrs)
+                (sut/xml->edn xml-example {:preserve-attrs?     true
+                                           :limit-eagerness?    true
+                                           :remove-empty-attrs? true})))
+    (is (match? edn-example-with-attrs-and-original-keys
+                (sut/xml->edn xml-example {:preserve-keys?   true
+                                           :limit-eagerness? true
+                                           :preserve-attrs?  true})))
+    (is (match? edn-example-original-keys-force-seq
+                (sut/xml->edn xml-example {:preserve-keys?   true
+                                           :limit-eagerness? true
+                                           :force-seq?       true})))
+    (is (nil?
+         (sut/xml->edn nil {:limit-eagerness? true})))
+    (is (nil?
+         (sut/xml->edn :edn {:limit-eagerness? true})))
+    (is (match? {} (sut/xml->edn {} {:limit-eagerness? true})))
+    (is (match? []
+                (sut/xml->edn [] {:limit-eagerness? true})))
+    (is (match? "XML" (sut/xml->edn "XML" {:limit-eagerness? true})))))
 
 
 (deftest edn->xml-test
@@ -169,7 +201,37 @@
                 (sut/edn->xml "XML")))
     (is (match? "100"
                 (sut/edn->xml 100 {:stringify-values? true})))
-    (is (nil? (sut/edn->xml 100)))))
+    (is (nil? (sut/edn->xml 100))))
+  (testing "Limiting eagerness does not impact correctness"
+    (is (match? xml-example
+                (-> xml-example
+                    (sut/xml->edn {:limit-eagerness? true
+                                   :preserve-attrs?  true})
+                    (sut/edn->xml {:limit-eagerness?  true
+                                   :to-xml-case?      true
+                                   :stringify-values? true}))))
+    (is (match? xml-example
+                (sut/edn->xml edn-example-with-attrs-and-original-keys
+                              {:to-xml-case?      true
+                               :limit-eagerness?  true
+                               :from-xml-case?    true
+                               :stringify-values? true})))
+    (is (match? xml-example
+                (sut/edn->xml edn-example-with-attrs
+                              {:to-xml-case?      true
+                               :limit-eagerness?  true
+                               :stringify-values? true})))
+    (is (match? [nil]
+                (sut/edn->xml nil {:limit-eagerness? true})))
+    (is (nil? (sut/edn->xml :edn {:limit-eagerness? true})))
+    (is (match? {}
+                (sut/edn->xml {} {:limit-eagerness? true})))
+    (is (match? ["XML"]
+                (sut/edn->xml "XML" {:limit-eagerness? true})))
+    (is (match? "100"
+                (sut/edn->xml 100 {:stringify-values? true
+                                   :limit-eagerness?  true})))
+    (is (nil? (sut/edn->xml 100 {:limit-eagerness? true})))))
 
 
 (def xml-test-string
@@ -192,6 +254,14 @@
                                      :support-dtd      false
                                      :remove-newlines? true})
                (sut/edn->xml-str  {:to-xml-case? true}))
+           (-> xml-test-string
+               string->stream
+               (sut/xml-source->edn {:preserve-attrs?  true
+                                     :limit-eagerness? true
+                                     :support-dtd      false
+                                     :remove-newlines? true})
+               (sut/edn->xml-str  {:limit-eagerness? true
+                                   :to-xml-case?     true}))
            (-> xml-test-string
                (sut/xml-str->edn {:preserve-attrs?  true
                                   :support-dtd      false
@@ -244,28 +314,66 @@
                   {:a {:b [1 2 3] :c {:d "e" :f [nil]}}}))
       (is (thrown-with-msg? IllegalArgumentException
                             #"The key :clj-xml.core/first is incompatible with class clojure.lang.PersistentArrayMap"
-            (sut/force-xml-seq-at-path nested-data [sut/first-child])))
+                            (sut/force-xml-seq-at-path nested-data [sut/first-child])))
       (is (thrown-with-msg? IllegalArgumentException
                             #"The key :c is incompatible with class clojure.lang.PersistentVector"
-            (sut/force-xml-seq-at-path nested-data [:a :b :c]))))))
+                            (sut/force-xml-seq-at-path nested-data [:a :b :c])))
+      (testing "Limiting eagerness does not impact correctness"
+        (is (match? (sut/force-xml-seq-at-path nested-data [:a :b sut/last-child] {:limit-eagerness? true})
+                    {:a {:b [1 2 [3]] :c {:d "e"}}}))
+        (is (match? (sut/force-xml-seq-at-path nested-data [:a :b sut/first-child] {:limit-eagerness? true})
+                    {:a {:b [[1] 2 3] :c {:d "e"}}}))
+        (is (match? (sut/force-xml-seq-at-path nested-data [:a :b sut/every-child] {:limit-eagerness? true})
+                    {:a {:b [[1] [2] [3]] :c {:d "e"}}}))
+        (is (match? (sut/force-xml-seq-at-path nested-data [:a :c :d] {:limit-eagerness? true})
+                    {:a {:b [1 2 3] :c {:d ["e"]}}}))
+        (is (match? (sut/force-xml-seq-at-path nested-data [:a :c :f] {:limit-eagerness? true})
+                    {:a {:b [1 2 3] :c {:d "e" :f [nil]}}}))
+        (is (thrown-with-msg? IllegalArgumentException
+                              #"The key :clj-xml.core/first is incompatible with class clojure.lang.PersistentArrayMap"
+                              (sut/force-xml-seq-at-path nested-data [sut/first-child] {:limit-eagerness? true})))
+        (is (thrown-with-msg? IllegalArgumentException
+                              #"The key :c is incompatible with class clojure.lang.PersistentVector"
+                              (sut/force-xml-seq-at-path nested-data [:a :b :c] {:limit-eagerness? true})))))))
 
 
 (deftest force-xml-seq-at-paths-test
   (testing "Parsed XML can coerce child nodes to collections"
-    (let [nested-data {:a {:b [1 2 3] :c {:d "e"}}}]
-      (is (match? {:a [{:b [[1] 2 [3]] :c {:d "e"}}]}
+    (let [nested-data {:a {:b [1 2 3]
+                           :c {:d "e"}}}]
+      (is (match? {:a [{:b [[1] 2 [3]]
+                        :c {:d "e"}}]}
                   (sut/force-xml-seq-at-paths nested-data [[:a :b sut/first-child]
                                                            [:a :b sut/last-child]
                                                            [:a]])))
-      (is (match? {:a [{:b [[1 2 3]] :c {:d "e"}}]}
+      (is (match? {:a [{:b [[1 2 3]]
+                        :c {:d "e"}}]}
                   (sut/force-xml-seq-at-paths nested-data [[:a]
-                                                           [:a sut/first-child :b]]))))))
+                                                           [:a sut/first-child :b]])))
+      (testing "Limiting eagerness does not impact correctness"
+        (is (match? {:a [{:b [[1] 2 [3]]
+                          :c {:d "e"}}]}
+                    (sut/force-xml-seq-at-paths nested-data
+                                                [[:a :b sut/first-child]
+                                                 [:a :b sut/last-child]
+                                                 [:a]]
+                                                {:limit-eagerness? true})))
+        (is (match? {:a [{:b [[1 2 3]]
+                          :c {:d "e"}}]}
+                    (sut/force-xml-seq-at-paths nested-data
+                                                [[:a]
+                                                 [:a sut/first-child :b]]
+                                                {:limit-eagerness? true})))))))
 
 
 (deftest xml-sequence-coercion-test
   (testing "parsed XML can be coerced"
     (is (match? edn-example-with-targeted-coercion
                 (sut/xml->edn' xml-example {:force-seq-for-paths [[:test-document :file :segments sut/every-child]
+                                                                  [:test-document]]})))
+    (is (match? edn-example-with-targeted-coercion
+                (sut/xml->edn' xml-example {:limit-eagerness?    true
+                                            :force-seq-for-paths [[:test-document :file :segments sut/every-child]
                                                                   [:test-document]]})))))
 
 
@@ -304,4 +412,43 @@
 
     (testing "Default branch"
       (is (= 12345
-             (sut/xml-seq->edn 12345))))))
+             (sut/xml-seq->edn 12345)))))
+  (testing "The inner `cond` dispatches as expected without eagerness"
+    (testing "First branch"
+      (is (nil? (sut/xml-seq->edn nil {:limit-eagerness? true})))
+      (is (= "xml" (sut/xml-seq->edn "xml" {:limit-eagerness? true}))))
+    (testing "Second branch"
+      (is (nil? (sut/xml-seq->edn [nil] {:limit-eagerness? true})))
+      (is (= "xml" (sut/xml-seq->edn ["xml"] {:limit-eagerness? true}))))
+    (testing "Third branch"
+      (is (= {:hello   "World"
+              :goodbye "Space"}
+             (sut/xml-seq->edn [{:tag     "Hello"
+                                 :content "World"}
+                                {:tag     "Goodbye"
+                                 :content "Space"}]
+                               {:limit-eagerness? true}))))
+    (testing "Fourth branch"
+      (is (= {}
+             (sut/xml-seq->edn {} {:limit-eagerness? true}))))
+    (testing "Fifth branch"
+      (is (= {:hello "Space"}
+             (sut/xml-seq->edn {:tag     "Hello"
+                                :content "Space"}
+                               {:limit-eagerness? true}))))
+    (testing "Sixth branch"
+      (is (match? [{:hello "World"}
+                   {:hello "Space"}]
+                  (sut/xml-seq->edn [{:tag     "Hello"
+                                      :content "World"}
+                                     {:tag     "Hello"
+                                      :content "Space"}]
+                                    {:limit-eagerness? true}))))
+    (testing "Seventh branch"
+      (is (= "12345"
+             (sut/xml-seq->edn 12345 {:stringify-values? true
+                                      :limit-eagerness?  true}))))
+
+    (testing "Default branch"
+      (is (= 12345
+             (sut/xml-seq->edn 12345 {:limit-eagerness? true}))))))

--- a/test/clj_xml/impl_test.clj
+++ b/test/clj_xml/impl_test.clj
@@ -90,6 +90,7 @@
     (is (= "xml"
            (sut/stringify "xml" false)))))
 
+
 (deftest map*-test
   (is (instance? clojure.lang.LazySeq (sut/map* inc [1 2 4] true)))
   (is (not (instance? clojure.lang.LazySeq (sut/map* inc [1 2 4] false))))

--- a/test/clj_xml/impl_test.clj
+++ b/test/clj_xml/impl_test.clj
@@ -90,3 +90,7 @@
     (is (= "xml"
            (sut/stringify "xml" false)))))
 
+(deftest map*-test
+  (is (instance? clojure.lang.LazySeq (sut/map* inc [1 2 4] true)))
+  (is (not (instance? clojure.lang.LazySeq (sut/map* inc [1 2 4] false))))
+  (is (vector? (sut/map* inc [1 2 4] false))))

--- a/test/clj_xml/samples/fermentables_test.clj
+++ b/test/clj_xml/samples/fermentables_test.clj
@@ -12,7 +12,8 @@
   (-> "fermentables.xml"
       io/resource
       io/input-stream
-      (xml/xml-source->edn {:skip-whitespace true})))
+      (xml/xml-source->edn {:skip-whitespace  true
+                            :limit-eagerness? true})))
 
 
 (deftest fermentables-test

--- a/test/clj_xml/samples/recipe_xml_test.clj
+++ b/test/clj_xml/samples/recipe_xml_test.clj
@@ -12,7 +12,8 @@
   (-> "recipe.xml"
       io/resource
       io/input-stream
-      (xml/xml-source->edn {:skip-whitespace true})))
+      (xml/xml-source->edn {:skip-whitespace  true
+                            :limit-eagerness? true})))
 
 
 (deftest recipe-test


### PR DESCRIPTION
# Proposed Changes

* Added
  * A new option `:limit-eagerness?` is available for all public functions. Enabling this option disables automatic, intermediate vector coercion.

## Pre-merge Checklist

- [x] Read and agree to the Contribution Guidelines and Code of Conduct
- [x] Write new tests for impacted functionality
- [x] Update the CHANGELOG and increment version
- [x] Update the README and other relevant documentation
